### PR TITLE
feat: add static IP configuration validation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,16 @@
 resource "proxmox_vm_qemu" "pve_vm" {
+  # Validate static IP configuration dependencies
+  lifecycle {
+    precondition {
+      condition = !var.pve_use_ci || var.pve_ci_use_dhcp || (
+        var.pve_ci_ip_address != "" &&
+        var.pve_ci_cidr_prefix_length != "" &&
+        var.pve_ci_gateway_address != ""
+      )
+      error_message = "When using static IP configuration (pve_ci_use_dhcp = false), all three variables must be provided: pve_ci_ip_address, pve_ci_cidr_prefix_length, and pve_ci_gateway_address."
+    }
+  }
+
   # Minimum Required Fields
   name        = var.pve_name
   target_node = var.pve_node

--- a/vars.tf
+++ b/vars.tf
@@ -204,6 +204,10 @@ variable "pve_ci_gateway_address" {
   type        = string
   description = "gateway to use for the VM, must be set if using static IP"
   default     = ""
+  validation {
+    condition     = var.pve_ci_gateway_address == "" || can(cidrhost("${var.pve_ci_gateway_address}/32", 0))
+    error_message = "pve_ci_gateway_address must be a valid IPv4 address or empty string."
+  }
 }
 
 variable "pve_ci_dns_servers" {


### PR DESCRIPTION
## Summary
- Add missing IPv4 validation for `pve_ci_gateway_address` (oversight from previous validation PR)
- Add lifecycle precondition to validate static IP configuration dependencies
- Ensure when `pve_ci_use_dhcp = false`, all three variables are provided: `pve_ci_ip_address`, `pve_ci_cidr_prefix_length`, and `pve_ci_gateway_address`

## Problem Solved
Previously, users could set `pve_ci_use_dhcp = false` but leave static IP variables empty, causing invalid IP configurations like `ip=/,gw=` in the resource.

## Test plan
- [x] Terraform validation passes
- [x] Invalid gateway IP addresses trigger validation errors
- [x] Static IP dependency validation implemented
- [x] DHCP mode allows empty static IP variables
- [x] Complete static IP configuration passes validation