### PR TITLE
feat: add optional DNS record creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,7 @@ resource "proxmox_vm_qemu" "pve_vm" {
 }
 
 resource "powerdns_record" "a_record" {
+  count   = var.create_dns_record ? 1 : 0
   zone    = "${var.pdns_zone}."
   name    = "${var.pdns_record_name}.${var.pdns_zone}."
   type    = "A"

--- a/output.tf
+++ b/output.tf
@@ -11,5 +11,5 @@ output "vm_ip_address" {
 }
 
 output "vm_dns_records" {
-  value = powerdns_record.a_record.records
+  value = length(powerdns_record.a_record) > 0 ? powerdns_record.a_record[0].records : []
 }

--- a/vars.tf
+++ b/vars.tf
@@ -278,6 +278,12 @@ variable "pve_serial_id" {
 # PowerDNS #
 ############
 
+variable "create_dns_record" {
+  type        = bool
+  description = "whether to create a PowerDNS A record for the VM"
+  default     = true
+}
+
 variable "pdns_zone" {
   type        = string
   description = "name of the PowerDNS zone to create the record in"


### PR DESCRIPTION
## Summary
- Add `create_dns_record` boolean variable (default: `true`)
- Make `powerdns_record` resource conditional using `count`
- Update `vm_dns_records` output to handle conditional resource
- Maintains backward compatibility with default DNS creation enabled

## Test plan
- [x] Terraform validation passes
- [x] Default behavior (DNS enabled) maintains compatibility
- [x] DNS disabled scenario works without errors
- [x] Output handles both enabled/disabled states correctly