### PR TITLE
feat: add configurable DNS TTL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,6 @@ resource "powerdns_record" "a_record" {
   zone    = "${var.pdns_zone}."
   name    = "${var.pdns_record_name}.${var.pdns_zone}."
   type    = "A"
-  ttl     = 60
+  ttl     = var.pdns_ttl
   records = [proxmox_vm_qemu.pve_vm.default_ipv4_address]
 }

--- a/vars.tf
+++ b/vars.tf
@@ -293,3 +293,13 @@ variable "pdns_record_name" {
   type        = string
   description = "name of the PowerDNS record to create"
 }
+
+variable "pdns_ttl" {
+  type        = number
+  description = "TTL (Time To Live) for the PowerDNS record in seconds"
+  default     = 60
+  validation {
+    condition     = var.pdns_ttl >= 30 && var.pdns_ttl <= 86400
+    error_message = "pdns_ttl must be between 30 and 86400 seconds (24 hours)."
+  }
+}


### PR DESCRIPTION
## Summary
- Add `pdns_ttl` variable with validation (30-86400 seconds range)
- Replace hardcoded TTL value (60) with configurable variable
- Maintains backward compatibility with 60-second default

## Test plan
- [x] Terraform validation passes
- [x] Default TTL behavior (60 seconds) maintains compatibility
- [x] Custom TTL values work correctly
- [x] Invalid TTL values trigger validation errors
- [x] TTL range validation enforces reasonable limits (30 seconds to 24 hours)