### PR TITLE
fix: remove Trivy from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,6 @@
 set -e
 
+terraform fmt -check -recursive
+terraform validate -no-color
 tflint --init
 tflint --recursive
-
-terraform fmt -check -recursive
-
-terraform validate -no-color
-
-trivy config ./ --exit-code 1


### PR DESCRIPTION
## Summary
- Remove Trivy security scan from pre-commit hook
- Keep terraform fmt, validate, and tflint checks
- Security scanning handled by CI workflows

## Test plan
- [x] Pre-commit hook runs successfully
- [x] Terraform validation still works
- [x] TFLint checks still work