### PR TITLE
feat: replace release workflow with reusable version and cleanup package.json

### DIFF
--- a/.github/workflows/push-main-release.yml
+++ b/.github/workflows/push-main-release.yml
@@ -9,6 +9,11 @@ on:
     paths-ignore:
       - 'CHANGELOG.md'
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   github-release:
     uses: Knighten-Homelab/gha-reusable-workflows/.github/workflows/semantic-release-to-gh.yaml@main

--- a/.github/workflows/push-main-release.yml
+++ b/.github/workflows/push-main-release.yml
@@ -11,31 +11,6 @@ on:
 
 jobs:
   github-release:
-    name: GitHub Release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: GitHub Release
-        id: semantic_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-          HUSKY: 0
-        run: |
-          OUTPUT=$(npx semantic-release)
-          echo "$OUTPUT"
-          NEW_VERSION=$(echo "$OUTPUT" | grep "Published release" | cut -d" " -f9)
-          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+    uses: Knighten-Homelab/gha-reusable-workflows/.github/workflows/semantic-release-to-gh.yaml@main
+    with:
+      runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -3,21 +3,12 @@
     "type": "git",
     "url": "https://github.com/Knighten-Homelab/terraform-proxmox-vm"
   },
-  "dependencies": {
-    "@semantic-release/changelog": "6.0.3",
-    "@semantic-release/commit-analyzer": "11.0.0",
-    "@semantic-release/git": "10.0.1",
-    "@semantic-release/github": "9.2.0",
-    "conventional-changelog-conventionalcommits": "7.0.2",
-    "semantic-release": "1f22.0.5"
-  },
   "devDependencies": {
     "@commitlint/cli": "^19.4.1",
     "@commitlint/config-conventional": "^19.4.1",
     "husky": "^9.1.6"
   },
   "scripts": {
-    "prepare": "husky",
-    "pre-commit-gha": ""
+    "prepare": "husky"
   }
 }


### PR DESCRIPTION
## Summary
- Replace release workflow with reusable workflow from gha-reusable-workflows
- Remove semantic-release dependencies from package.json
- Remove unused pre-commit-gha script

## Test plan
- [ ] Verify release workflow still functions after merge to main
- [ ] Ensure npm install works and commit-msg hook still functions